### PR TITLE
defect/DE8836-jekyll-contentful-issues

### DIFF
--- a/lib/jekyll-contentful/client.rb
+++ b/lib/jekyll-contentful/client.rb
@@ -9,7 +9,7 @@ module Jekyll
         @site = site || self.class.scaffold(base)
         @options = options
         @entries = {}
-        @limit = 500
+        @limit = 1000
         @log_color = 'green'
       end
 


### PR DESCRIPTION
This PR changes the limit back to 1000 to reduce the number of API
calls we are making. In Contentful, the Article content model had the
tags and recommended media fields disabled in the API response. As a
result, querying with limit of 1000 works again without throwing a 400
Response too Large error.