### PR TITLE
US22125 Reduce Log Verbosity and add page limit

### DIFF
--- a/lib/jekyll-contentful/command.rb
+++ b/lib/jekyll-contentful/command.rb
@@ -9,11 +9,12 @@ module Jekyll
             c.alias(:cfl)
             c.syntax "contentful [options]"
             c.description 'Imports data from Contentful'
+            c.option 'clean', '-f', '--force', 'Remove existing collections data prior to importing'
             c.option 'collections', '-c', '--collections COL1[,COL2]', Array, 'Return content for specific collections'
             c.option 'limit', '-n', '--limit N', Integer, 'Limit the number of entries returned, e.g. "--limit 10"'
-            c.option 'recent', '-d', '--recent STR', String, 'Limit the number of entries returned by time, e.g. "--recent 1.day.ago"'
+            c.option 'pagelimit', '-p', '--pagelimit N', Integer, 'Limit the number of entries returned in each page, e.g. "--pagelimit 500"'
             c.option 'query', '-q', '--query STR', String, 'Additional query string params to append to API requests, e.g. "--query title=Something"'
-            c.option 'clean', '-f', '--force', 'Remove existing collections data prior to importing'
+            c.option 'recent', '-d', '--recent STR', String, 'Limit the number of entries returned by time, e.g. "--recent 1.day.ago"'
             c.option 'sites', '-s', '--sites SITE1[,SITE2]', 'Return only content for specific sites'
             c.action do |args, options|
               Jekyll::Contentful::Client.new(args: args, options: options).sync!


### PR DESCRIPTION
This PR implements the following:

- Reduce Log Verbosity
- Add a --pagelimit flag

The new --pagelimit flag gives control to the jekyll contentful command
to dictate how many results come back with each page. For example, if
Artlce has 100 total records in Contentful, using the --pagelimit flag
with a value of 30 would result in 4 API calls that returned a total of
100 records.

This differs from the --limit flag, in which you specify the total
number of records you want returned. For example, --limit 10 would
result in 1 API call that returned 10 records.